### PR TITLE
Fixed broken soundcloud plugin

### DIFF
--- a/packages/soundcloud/src/index.ts
+++ b/packages/soundcloud/src/index.ts
@@ -29,10 +29,8 @@ export class SoundCloudPlugin extends ExtractorPlugin {
     if (options.oauthToken && typeof options.oauthToken !== "string") {
       throw new DisTubeError("INVALID_TYPE", "string", options.oauthToken, "oauthToken");
     }
-    this.soundcloud = new Soundcloud({
-      clientId: options.clientId,
-      oauthToken: options.oauthToken,
-    });
+
+    this.soundcloud = new Soundcloud(options.clientId, options.oauthToken);
   }
   search<T>(query: string, type?: SearchType.Track, limit?: number, options?: ResolveOptions<T>): Promise<Song<T>[]>;
   search<T>(


### PR DESCRIPTION
Package soundcloud.ts 0.5.5 provide unexpected broken change, they changed the way of how pass client and token. Because of that, you are not able to fetch the songs/playlist even without credentials.

You can read more about that in [distube.js support channel](https://discord.com/channels/732254550689316914/1272000531908263977)
