### PR TITLE
[ytdlp] Fixes an issue with incorrect warning message.

### DIFF
--- a/packages/yt-dlp/src/index.ts
+++ b/packages/yt-dlp/src/index.ts
@@ -13,7 +13,7 @@ export class YtDlpPlugin extends PlayableExtractorPlugin {
 
   override init(distube: DisTube) {
     super.init(distube);
-    if (this.distube.plugins[this.distube.plugins.length - 1] !== this) {
+    if (this.distube.plugins[this.distube.plugins.length - 2] !== this) {
       // eslint-disable-next-line no-console
       console.warn(
         `[${this.constructor.name}] This plugin is not the last plugin in distube. This is not recommended.`,


### PR DESCRIPTION
# What's PR for?
 fix the small issue for `@distube/ytdlp` package.

# PR details
When using the @distube/ytdlp package, the message "[YtDlpPlugin] This plugin is not the last plugin in distube. This is not recommended." is displayed on the console. The problem is that the version check process compares the local YtDlpPlugin version with the remote (released) DeezerPlugin version. Therefore, fixing the process to correctly compare the local and remote YtDlpPlugin versions would fix this problem.

# PR priority
 LOW